### PR TITLE
Fix du problème où sur un clic droit > décomposer, l'outil structure …

### DIFF
--- a/src/PartieEditeur/ElementGraphique.js
+++ b/src/PartieEditeur/ElementGraphique.js
@@ -384,7 +384,7 @@ class ElementGraphique extends HTMLElement {
 		if (this.peutEtreDecompose()) {
 			lesOptions.push(
 				new ElementMenu("Décomposer", () => {
-					editeur.selectTool(6); // Outil de liaison
+					editeur.selectTool(0); // Outil de liaison
 					editeur._pointePrecedementLien = this;
 					this.classList.add("pointePourLien");
 				}),


### PR DESCRIPTION
…itérative bornée était sélectionnée au lieu de l'outil décomposer